### PR TITLE
Add community documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
 node_js:
-  - "6"
-script:
-  - npm run lint
-  - npm run test
-  - npm run build
-  - npm run test:examples
+  - 'node'
+  - '8'
+  - '7'
+before_script:
+  - npm prune
+  - greenkeeper-lockfile-update
+after_success:
+  - npm run semantic-release
 branches:
-  only:
-    - master
+  except:
+    - /^v\d+\.\d+\.\d+$/
+before_install:
+- npm install -g npm@5
+- npm install -g greenkeeper-lockfile@1
+after_script: greenkeeper-lockfile-upload

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at richard.littauer@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contribute
+
+Please contribute! Here are some things that would be great:
+- Open an issue!
+- Open a pull request!
+- Say hi! 👋
+
+Please abide by the [code of conduct](CODE_OF_CONDUCT.md).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "url": "git+https://github.com/magalhini/react-text-resize.git"
   },
   "keywords": [
+    "component",
+    "react",
+    "resize",
+    "text",
+    "typography",
     "react",
     "text",
     "resize",
@@ -55,5 +60,8 @@
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1"
-  }
+  },
+  "contributors": [
+    "magalhini@gmail.com"
+  ]
 }


### PR DESCRIPTION
Dearest humans,

You are missing some important community files. I am adding them here for you!

Here are some things you should do manually before merging this Pull Request:

- [ ] Update the Contributing guide to include any repository-specific requests, or to point to a global Contributing document.
- [ ] Update the email address in the Code of Conduct: the default is currently richard.littauer@gmail.com.
- [ ] Check that nothing drastic happened in the `package.json`.
- [ ] Check the `package.json` keywords. We added some from your GitHub topics.
- [ ] Add these keywords (from your `package.json` as GitHub topics to your repo: "component", "react", "resize", "text", "typography", "react", "text", "resize", "fit", "paragraph".
- [ ] Check that the bugs field in the package.json is OK. It doesn't match what we'd expect, which would be https://github.com/magalhini/react-text-resize/issues
- [ ] We expected the repository url in the `package.json` to be https://github.com/magalhini/react-text-resize, and it wasn't. Is this intentional?
- [ ] If there are more contributors, add them to the Contributors field in the `package.json`.
- [ ] Check if .travis.yml was overwritten or not.
